### PR TITLE
Mouse and rotation refactor

### DIFF
--- a/godot/src/Interface/DebugInterface.tscn
+++ b/godot/src/Interface/DebugInterface.tscn
@@ -16,6 +16,7 @@ margin_left = -16.0
 margin_top = -16.0
 margin_right = 16.0
 margin_bottom = 16.0
+mouse_filter = 2
 texture = ExtResource( 2 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/godot/src/Player/Camera.gd
+++ b/godot/src/Player/Camera.gd
@@ -2,6 +2,28 @@ extends Camera
 
 onready var shake_tween:=$ShakeTween
 
+export var joypad_rotation_speed: = 2.0 #should these still be on Player for ease of change?
+export var sensitivity: = 0.001
+
+
+func _physics_process(delta: float) -> void:
+	joypad_camera_rotation(delta)
+
+
+func _unhandled_input(event) -> void:
+	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
+		do_screen_rotation(-event.relative.y * sensitivity, -event.relative.x * sensitivity)
+
+
+func joypad_camera_rotation(delta: float)->void:
+	var direction: = Vector3(
+		Input.get_action_strength("camera_up") - Input.get_action_strength("camera_down"),
+		Input.get_action_strength("camera_left") - Input.get_action_strength("camera_right"),
+		0.0
+	)
+	var rotation: = direction * joypad_rotation_speed * delta
+	do_screen_rotation(rotation.x, rotation.y)
+
 
 func screen_kick(intensity: float, duration: float)->void:
 	var temp_intensity = rand_range(intensity/2, intensity)
@@ -9,3 +31,9 @@ func screen_kick(intensity: float, duration: float)->void:
 	shake_tween.interpolate_property(self, "rotation_degrees", rotation_degrees, 
 		temp_rotation, duration, Tween.TRANS_CIRC, Tween.EASE_OUT)
 	shake_tween.start()
+
+
+func do_screen_rotation(x_axis_delta: float, y_axis_delta: float) -> void:
+	rotate_object_local(Vector3(1,0,0), x_axis_delta)
+	rotate_object_local(Vector3(0,1,0), y_axis_delta)
+	rotation_degrees.z = 0

--- a/godot/src/Player/Camera.gd
+++ b/godot/src/Player/Camera.gd
@@ -1,28 +1,26 @@
 extends Camera
 
-onready var shake_tween:=$ShakeTween
+onready var shake_tween: = $ShakeTween
 
-export var joypad_rotation_speed: = 2.0 #should these still be on Player for ease of change?
+export var joypad_rotation_speed: = 2.0
 export var sensitivity: = 0.001
-
-
-func _physics_process(delta: float) -> void:
-	joypad_camera_rotation(delta)
 
 
 func _unhandled_input(event) -> void:
 	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
-		do_screen_rotation(-event.relative.y * sensitivity, -event.relative.x * sensitivity)
+		rotate_local(-event.relative.y * sensitivity, -event.relative.x * sensitivity)
+	if event is InputEventJoypadMotion:
+		rotate_joypad(get_physics_process_delta_time())
 
 
-func joypad_camera_rotation(delta: float)->void:
+func rotate_joypad(delta: float)->void:
 	var direction: = Vector3(
 		Input.get_action_strength("camera_up") - Input.get_action_strength("camera_down"),
 		Input.get_action_strength("camera_left") - Input.get_action_strength("camera_right"),
 		0.0
 	)
 	var rotation: = direction * joypad_rotation_speed * delta
-	do_screen_rotation(rotation.x, rotation.y)
+	rotate_local(rotation.x, rotation.y)
 
 
 func screen_kick(intensity: float, duration: float)->void:
@@ -33,7 +31,7 @@ func screen_kick(intensity: float, duration: float)->void:
 	shake_tween.start()
 
 
-func do_screen_rotation(x_axis_delta: float, y_axis_delta: float) -> void:
+func rotate_local(x_axis_delta: float, y_axis_delta: float) -> void:
 	rotate_object_local(Vector3(1,0,0), x_axis_delta)
 	rotate_object_local(Vector3(0,1,0), y_axis_delta)
 	rotation_degrees.z = 0

--- a/godot/src/Player/Player.gd
+++ b/godot/src/Player/Player.gd
@@ -34,8 +34,6 @@ onready var ray: RayCast = $Camera/RayCast
 onready var sound: AudioStreamPlayer3D = $AudioStreamPlayer3D
 
 export var move_speed: = 8.0
-export var sensitivity: = 0.001
-export var joypad_rotation_speed: = 60.0
 export var gravity: = 100.0
 export var jump_force: = 30.0
 export var hit_decal: PackedScene
@@ -44,25 +42,20 @@ var velocity: = Vector3.ZERO
 var horizontal_move: = Vector3.ZERO
 
 
-func _physics_process(delta):
+func _physics_process(delta) -> void:
 	get_horizontal_input()
-	joypad_camera_rotation(delta)
 	motion(delta)
 	emit_signal("camera_rotation_updated", camera.rotation_degrees)
 
 
-func _unhandled_input(event):
-	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
-		rotate_y(-event.relative.x * sensitivity)
-		camera.rotate_x(event.relative.y * sensitivity)
-		camera.rotation_degrees.x = clamp(camera.rotation_degrees.x, -45, 45)
+func _unhandled_input(event) -> void:
 	if event.is_action_pressed("ui_cancel"):
 		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 	if event.is_action_pressed("fire") and ray.is_colliding():
 		shoot()
 
 
-func get_horizontal_input()->void:
+func get_horizontal_input() -> void:
 	horizontal_move = Vector3.ZERO
 	horizontal_move += camera.global_transform.basis.x * (Input.get_action_strength("strafe_right") 
 		- Input.get_action_strength("strafe_left"))
@@ -70,7 +63,7 @@ func get_horizontal_input()->void:
 		- Input.get_action_strength("forward"))
 
 
-func motion(delta: float)->void:
+func motion(delta: float) -> void:
 	var temp_velocity = Vector2(horizontal_move.x, horizontal_move.z).normalized() * move_speed
 	
 	velocity.x = temp_velocity.x
@@ -82,16 +75,6 @@ func motion(delta: float)->void:
 	else:
 		velocity.y -= gravity * delta
 	move_and_slide(velocity, Vector3.UP)
-
-
-func joypad_camera_rotation(delta: float)->void:
-	var direction: = Vector3(
-		Input.get_action_strength("camera_up") - Input.get_action_strength("camera_down"),
-		Input.get_action_strength("camera_left") - Input.get_action_strength("camera_right"),
-		0.0
-	)
-	rotation_degrees += direction * joypad_rotation_speed * delta
-	camera.rotation_degrees.x = clamp(camera.rotation_degrees.x, -45, 45)
 
 
 func shoot()->void:

--- a/godot/src/Player/Player.gd
+++ b/godot/src/Player/Player.gd
@@ -5,24 +5,6 @@ This is a simple first person controller
 that moves the character in relation to
 the direction the camera is pointing with
 WASD and the left joystick.
-
-I added the jump physics here as well, 
-they seem to be too small for its own video
-but I'd like feedback.
-
-I added two different functions for the camera.
-The joypad version works pretty well, but the
-mouse one makes me nauseous.  That's why I 
-added the debug labels and the reticle.
-
-I added a raycast as a child of the camera, 
-made a sprite3d for a decal when hitting something
-and a shoot method to tell the scene to make a 
-decal at a specific spot.  The player part seems
-to be working okay, but the decal is being created 
-a bit wonky.
-
-Feedback is appreciated.
 """
 
 
@@ -69,8 +51,7 @@ func motion(delta: float) -> void:
 	velocity.x = temp_velocity.x
 	velocity.z = temp_velocity.y
 	
-	if is_on_floor():
-		if Input.is_action_just_pressed("jump"):
+	if is_on_floor() and Input.is_action_just_pressed("jump"):
 			velocity.y = jump_force
 	else:
 		velocity.y -= gravity * delta

--- a/godot/src/Player/Player.tscn
+++ b/godot/src/Player/Player.tscn
@@ -12,11 +12,11 @@ collision_mask = 6
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 1, 0 )
+transform = Transform( 1, 0, 0, 0, -4.37114e-008, -1, 0, 1, -4.37114e-008, 0, 1, 0 )
 shape = SubResource( 1 )
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( -1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 1.5, 0 )
+transform = Transform( -1, 0, -1.50996e-007, 0, 1, 0, 1.50996e-007, 0, -1, 0, 1.5, 0 )
 keep_aspect = 0
 current = true
 fov = 60.0

--- a/godot/src/Player/Player.tscn
+++ b/godot/src/Player/Player.tscn
@@ -12,11 +12,11 @@ collision_mask = 6
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
-transform = Transform( 1, 0, 0, 0, -4.37114e-008, -1, 0, 1, -4.37114e-008, 0, 1, 0 )
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 1, 0 )
 shape = SubResource( 1 )
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( -1, 0, -1.50996e-007, 0, 1, 0, 1.50996e-007, 0, -1, 0, 1.5, 0 )
+transform = Transform( -1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, 0, 1.5, 0 )
 keep_aspect = 0
 current = true
 fov = 60.0


### PR DESCRIPTION
**Reticle's mouse filter set to _MOUSE_FILTER_IGNORE_**
Player's _unhandled_input was not triggering because MOUSE_FILTER_PASS, the original setting, handles the input even when it isn't grabbed by a parent.

**Camera rotation code moved to Camera script**
The player object was being rotated on the X-axis while the camera was being rotated on the Y-axis to simulate the look-around. I've combined the moves into Spatial's rotate_object_local calls so
that the Camera can do all the rotation work while the player object handles only movement.